### PR TITLE
Fix placement of prefabs inside prefab stages

### DIFF
--- a/Editor/Scripts/PlacementModes/Modes/LineDrawMode.cs
+++ b/Editor/Scripts/PlacementModes/Modes/LineDrawMode.cs
@@ -66,6 +66,7 @@ namespace PrefabPalette
             if (spawnedObjParent == null)
             {
                 spawnedObjParent = new GameObject($"Line:{context.SelectedPrefab.name}");
+                spawnedObjParent.transform.SetParent(ScenePlacer.GetAppropriateParent(context.SelectedPrefab));
                 spawnedObjParent.transform.position = startPoint;
             }
 

--- a/Editor/Scripts/PlacementModes/Modes/SinglePrefabMode.cs
+++ b/Editor/Scripts/PlacementModes/Modes/SinglePrefabMode.cs
@@ -35,7 +35,8 @@ namespace PrefabPalette
 
                 lastSurfaceNormal = SceneInteraction.SurfaceNormal;
 
-                currentPlacedObject = (GameObject)PrefabUtility.InstantiatePrefab(context.SelectedPrefab);
+                Transform parent = ScenePlacer.GetAppropriateParent(context.SelectedPrefab);
+                currentPlacedObject = (GameObject)PrefabUtility.InstantiatePrefab(context.SelectedPrefab, parent);
                 currentPlacedObject.transform.SetPositionAndRotation(SceneInteraction.Position + settings.freeMode_placementOffset, context.Settings.placer_alignWithSurface ? Quaternion.FromToRotation(Vector3.up, lastSurfaceNormal) : Quaternion.identity);
                 Undo.RegisterCreatedObjectUndo(currentPlacedObject, "Placed Prop");
 

--- a/Editor/Scripts/Utilities/ScenePlacer.cs
+++ b/Editor/Scripts/Utilities/ScenePlacer.cs
@@ -1,0 +1,21 @@
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+
+namespace PrefabPalette
+{
+    public static class ScenePlacer
+    {
+        public static Transform GetAppropriateParent(GameObject prefab)
+        {
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage != null && prefabStage.stageHandle.IsValid())
+            {
+                return prefabStage.prefabContentsRoot.transform;
+            }
+
+            // Null parent is simply a transform in the active scene
+            return null;
+        }
+    }
+}

--- a/Editor/Scripts/Utilities/ScenePlacer.cs.meta
+++ b/Editor/Scripts/Utilities/ScenePlacer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d53efbd7420e83b4bbbdcd80585683c5


### PR DESCRIPTION
This does so with a new utility script that checks for an active prefab stage, and returns an appropriate parent for prefabs to be instantiated under.

The current prefab is passed into a static function, but this parameter is unused; I imagine that it could be used to automatically group prefabs under a single parent in a future.