### PR TITLE
Fix PathDr crashing worker threads and returning null.

### DIFF
--- a/Editor/Scripts/Utilities/PathDr.cs
+++ b/Editor/Scripts/Utilities/PathDr.cs
@@ -22,7 +22,7 @@ namespace PrefabPalette
 
         static PathDr()
         {
-            Init();
+            EditorApplication.delayCall += Init;
         }
 
         static void Init()
@@ -31,21 +31,28 @@ namespace PrefabPalette
             collectionsPath = EditorPrefs.GetString(CollectionsPathKey, string.Empty);
 
             // If the path for the tools root folder isn't set or the directory no longer
-            // exists, look for it in th asset database.
+            // exists, look for it in the asset database.
             if (string.IsNullOrEmpty(toolPath) || !Directory.Exists(toolPath))
             {
                 var root = FindFolder("PrefabPalette");
-                toolPath = Path.Combine(root, "Editor");
-                // If the path's found, save it to editor prefs.
-                if (!string.IsNullOrEmpty(toolPath))
+
+                if (string.IsNullOrEmpty(root))
                 {
-                    EditorPrefs.SetString(ToolPathKey, toolPath);
-                }
-                else
-                {
-                    Debug.LogError($"PrefabPalette/{nameof(PathDr)}Can't find editor folder!");
+                    Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Can't find PrefabPalette folder!");
                     return;
                 }
+
+                toolPath = Path.Combine(root, "Editor");
+
+                // Verify the Editor folder exists
+                if (!Directory.Exists(toolPath))
+                {
+                    Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Can't find Editor folder at '{toolPath}'!");
+                    return;
+                }
+
+                // Save the valid path to editor prefs
+                EditorPrefs.SetString(ToolPathKey, toolPath);
             }
 
             generatedFolderPath = Path.Combine(toolPath, "Generated");
@@ -60,6 +67,12 @@ namespace PrefabPalette
 
         private static bool ValidateFolderPath(string fullPath)
         {
+            if (string.IsNullOrEmpty(fullPath))
+            {
+                Debug.LogError($"PrefabPalette/{nameof(ValidateFolderPath)}: Received null or empty path!");
+                return false;
+            }
+
             if (!Directory.Exists(fullPath))
             {
                 // Get parent folder and new folder name
@@ -69,6 +82,13 @@ namespace PrefabPalette
                 if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(folderName))
                 {
                     Debug.LogError($"PrefabPalette/{nameof(ValidateFolderPath)}: Invalid path '{fullPath}'");
+                    return false;
+                }
+
+                // Check if parent exists before trying to create subfolder
+                if (!Directory.Exists(parent))
+                {
+                    Debug.LogError($"PrefabPalette/{nameof(ValidateFolderPath)}: Parent directory doesn't exist: '{parent}'");
                     return false;
                 }
 
@@ -93,9 +113,68 @@ namespace PrefabPalette
         /// <returns>
         /// Path to /PrefabPalette/Editor
         /// </returns>
-        public static string GetToolPath => toolPath;
+        /// <returns>
+        /// Path to /PrefabPalette/Editor
+        /// </returns>
+        public static string GetToolPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(toolPath))
+                {
+                    // Try to find and initialize the tool path
+                    var root = FindFolder("PrefabPalette");
 
-        public static string GetGeneratedFolderPath => generatedFolderPath;
+                    if (string.IsNullOrEmpty(root))
+                    {
+                        Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Can't find PrefabPalette folder!");
+                        return string.Empty;
+                    }
+
+                    // Verify the root folder actually exists
+                    if (!Directory.Exists(root))
+                    {
+                        Debug.LogError($"PrefabPalette/{nameof(PathDr)}: PrefabPalette folder path is invalid: '{root}'");
+                        return string.Empty;
+                    }
+
+                    toolPath = Path.Combine(root, "Editor");
+
+                    // Verify the Editor folder exists
+                    if (!Directory.Exists(toolPath))
+                    {
+                        Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Can't find Editor folder at '{toolPath}'!");
+                        toolPath = string.Empty; // Reset it so we don't cache a bad path
+                        return string.Empty;
+                    }
+
+                    // Save the valid path to editor prefs
+                    EditorPrefs.SetString(ToolPathKey, toolPath);
+                }
+
+                return toolPath;
+            }
+        }
+
+        public static string GetGeneratedFolderPath
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(generatedFolderPath))
+                {
+                    if (string.IsNullOrEmpty(GetToolPath))
+                    {
+                        Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Cannot get Generated folder - toolPath is not initialized!");
+                        return string.Empty;
+                    }
+
+                    generatedFolderPath = Path.Combine(GetToolPath, "Generated");
+                    ValidateFolderPath(generatedFolderPath);
+                }
+
+                return generatedFolderPath ?? string.Empty;
+            }
+        }
 
         /// <summary>
         /// Returns the path to the folder where prefab collections are generated.
@@ -104,18 +183,78 @@ namespace PrefabPalette
         /// Note: Always assumed to be in the tools root folder,
         /// a new one will be created here if it's moved or deleted
         /// </remarks>
-        public static string GetCollectionsFolder => collectionsPath;
+        public static string GetCollectionsFolder
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(collectionsPath))
+                {
+                    string genFolder = GetGeneratedFolderPath;
 
-        public static string GetModeSettingsFolder => modeSettingsPath;
-        
+                    if (string.IsNullOrEmpty(genFolder))
+                    {
+                        Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Cannot get Collections folder - Generated folder is not available!");
+                        return string.Empty;
+                    }
+
+                    collectionsPath = Path.Combine(genFolder, "Collections");
+                    ValidateFolderPath(collectionsPath);
+                }
+
+                return collectionsPath ?? string.Empty;
+            }
+        }
+
+        public static string GetModeSettingsFolder
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(modeSettingsPath))
+                {
+                    string genFolder = GetGeneratedFolderPath;
+
+                    if (string.IsNullOrEmpty(genFolder))
+                    {
+                        Debug.LogError($"PrefabPalette/{nameof(PathDr)}: Cannot get Mode Settings folder - Generated folder is not available!");
+                        return string.Empty;
+                    }
+
+                    modeSettingsPath = Path.Combine(genFolder, "Mode Settings");
+                    ValidateFolderPath(modeSettingsPath);
+                }
+
+                return modeSettingsPath ?? string.Empty;
+            }
+        }
+
         /// <returns>
-        /// GUID of <paramref name="folderName"/> from asset database
+        /// Path of <paramref name="folderName"/> from asset database, or null if not found
         /// </returns>
         private static string FindFolder(string folderName)
         {
-            string[] guids = AssetDatabase.FindAssets($"t:Folder {folderName}");
-            return guids.Select(AssetDatabase.GUIDToAssetPath)
-                        .FirstOrDefault(path => path.EndsWith(folderName));
+            if (string.IsNullOrEmpty(folderName))
+            {
+                Debug.LogError($"PrefabPalette/{nameof(FindFolder)}: Received null or empty folder name!");
+                return null;
+            }
+
+            try
+            {
+                string[] guids = AssetDatabase.FindAssets($"t:Folder {folderName}");
+
+                if (guids == null || guids.Length == 0)
+                {
+                    return null;
+                }
+
+                return guids.Select(AssetDatabase.GUIDToAssetPath)
+                            .FirstOrDefault(path => !string.IsNullOrEmpty(path) && path.EndsWith(folderName));
+            }
+            catch (System.Exception ex)
+            {
+                Debug.LogError($"PrefabPalette/{nameof(FindFolder)}: Exception while searching for folder '{folderName}': {ex.Message}");
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Noticed paths returning null and worker threads crashing while packaging v1.0.3.  

Fixed with the following:
* Use lazy initialisation for each path property instead of solely relying on Init.
* Delay Init until Editor is ready.

Closes #30