### PR TITLE
Add issue templates for bug and feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug Report
+about: Report a bug or broken behaviour
+labels: bug
+---
+
+## Description
+<!-- What's broken? -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+<!-- What should happen? -->
+
+## Actual Behaviour
+<!-- What actually happens? -->
+
+## Possible Solutions
+<!-- Optional: any ideas how to fix it? -->
+
+## Additional Context
+<!-- Logs, screenshots, environment info, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Summary
+<!-- One sentence description of the feature -->
+
+## Problem / Motivation
+<!-- What problem does this solve? Why is it needed? -->
+
+## Proposed Solution
+<!-- How do you think it should work? -->
+
+## Alternatives Considered
+<!-- Any other approaches you thought about? -->
+
+## Additional Context
+<!-- Mockups, examples, related issues, etc. -->


### PR DESCRIPTION
Add two GitHub issue templates under .github/ISSUE_TEMPLATE: bug_report.md and feature_request.md. These templates standardize reporting by providing sections for description, reproduction steps, expected vs actual behaviour, and additional context for bugs, and summary, problem/motivation, proposed solution, alternatives, and additional context for feature requests.